### PR TITLE
Implement `is_full` and return overwritten values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,30 @@ impl<T> CircularQueue<T> {
         self.data.is_empty()
     }
 
+    /// Returns `true` if the queue is full.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use circular_queue::CircularQueue;
+    ///
+    /// let mut queue = CircularQueue::with_capacity(5);
+    ///
+    /// assert!(!queue.is_full());
+    ///
+    /// queue.push(1);
+    /// queue.push(2);
+    /// queue.push(3);
+    /// queue.push(4);
+    /// queue.push(5);
+    ///
+    /// assert!(queue.is_full());
+    /// ```
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.capacity() == self.len()
+    }
+
     /// Returns the capacity of the queue.
     ///
     /// # Examples
@@ -195,7 +219,7 @@ impl<T> CircularQueue<T> {
             return;
         }
 
-        if self.data.len() < self.capacity() {
+        if !self.is_full() {
             self.data.push(x);
         } else {
             self.data[self.insertion_index] = x;


### PR DESCRIPTION
Currently, checking whether the queue is full is done by comparing `capacity` to `len`. The newly added `is_full` allows for this check to be simplified. It does the exact same operation in the background but provides a nicer user-facing interface.

The `push` function has also been modified to utilize `is_full`, but more importantly to return an `Option<T>`. This option will be `Some(T)` if the queue was full prior to pushing a new value and contain the overwritten item. It will be `None` otherwise.

No dedicated new tests have been added, but doc-tests have been added/modified to account for and test the new behavior. All tests pass.